### PR TITLE
feat(logger): add slog http middleware

### DIFF
--- a/logger/http.go
+++ b/logger/http.go
@@ -3,6 +3,7 @@ package logger
 import (
 	"log/slog"
 	"net/http"
+	"strings"
 	"time"
 )
 
@@ -53,7 +54,7 @@ func (l *httpLogger) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			slog.String("method", r.Method),
 			slog.String("path", r.URL.Path),
 			slog.String("protocol", r.Proto),
-			slog.String("remote_ip", r.RemoteAddr),
+			slog.String("remote_ip", getClientIP(r)),
 			slog.String("user_agent", r.UserAgent()),
 			slog.Int("status", rw.status),
 			slog.Int("bytes", rw.size),
@@ -69,6 +70,19 @@ func (l *httpLogger) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}()
 
 	l.next.ServeHTTP(rw, r)
+}
+
+func getClientIP(r *http.Request) string {
+	if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
+		// X-Forwarded-For can contain a comma-separated list of IPs.
+		// The first one is the original client.
+		ips := strings.Split(xff, ",")
+		return strings.TrimSpace(ips[0])
+	}
+	if xrip := r.Header.Get("X-Real-IP"); xrip != "" {
+		return strings.TrimSpace(xrip)
+	}
+	return r.RemoteAddr
 }
 
 // NewHTTPLogger returns a middleware that logs HTTP requests using slog.

--- a/logger/http.go
+++ b/logger/http.go
@@ -1,0 +1,87 @@
+package logger
+
+import (
+	"log/slog"
+	"net/http"
+	"time"
+)
+
+type responseWriter struct {
+	http.ResponseWriter
+	status int
+	size   int
+}
+
+func (rw *responseWriter) WriteHeader(status int) {
+	if rw.status == 0 {
+		rw.status = status
+	}
+	rw.ResponseWriter.WriteHeader(status)
+}
+
+func (rw *responseWriter) Write(b []byte) (int, error) {
+	if rw.status == 0 {
+		rw.status = http.StatusOK
+	}
+	size, err := rw.ResponseWriter.Write(b)
+	rw.size += size
+	return size, err
+}
+
+type httpLogger struct {
+	log  *slog.Logger
+	next http.Handler
+}
+
+func (l *httpLogger) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	start := time.Now()
+
+	rw := &responseWriter{
+		ResponseWriter: w,
+		status:         0,
+		size:           0,
+	}
+
+	defer func() {
+		if rw.status == 0 {
+			rw.status = http.StatusOK
+		}
+
+		duration := time.Since(start)
+
+		attrs := []slog.Attr{
+			slog.String("method", r.Method),
+			slog.String("path", r.URL.Path),
+			slog.String("protocol", r.Proto),
+			slog.String("remote_ip", r.RemoteAddr),
+			slog.String("user_agent", r.UserAgent()),
+			slog.Int("status", rw.status),
+			slog.Int("bytes", rw.size),
+			slog.Duration("duration", duration),
+		}
+
+		level := slog.LevelInfo
+		if rw.status >= 500 {
+			level = slog.LevelError
+		}
+
+		l.log.LogAttrs(r.Context(), level, "HTTP Request", attrs...)
+	}()
+
+	l.next.ServeHTTP(rw, r)
+}
+
+// NewHTTPLogger returns a middleware that logs HTTP requests using slog.
+func NewHTTPLogger(log *slog.Logger) func(http.Handler) http.Handler {
+	if log == nil {
+		log = slog.Default()
+	}
+
+	return func(next http.Handler) http.Handler {
+		l := &httpLogger{
+			log:  log,
+			next: next,
+		}
+		return l
+	}
+}

--- a/logger/http_test.go
+++ b/logger/http_test.go
@@ -1,0 +1,158 @@
+package logger
+
+import (
+	"bytes"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewHTTPLogger(t *testing.T) {
+	t.Run("logs 200 OK as Info", func(t *testing.T) {
+		var buf bytes.Buffer
+		h := slog.NewJSONHandler(&buf, nil)
+		log := slog.New(h)
+
+		middleware := NewHTTPLogger(log)
+
+		handler := middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte("OK"))
+		}))
+
+		req := httptest.NewRequest(http.MethodGet, "/test", nil)
+		req.RemoteAddr = "127.0.0.1:1234"
+		req.Header.Set("User-Agent", "Test-Agent")
+
+		rr := httptest.NewRecorder()
+
+		handler.ServeHTTP(rr, req)
+
+		assert.Equal(t, http.StatusOK, rr.Code)
+		assert.Equal(t, "OK", rr.Body.String())
+
+		var logEntry map[string]interface{}
+		err := json.Unmarshal(buf.Bytes(), &logEntry)
+		assert.NoError(t, err)
+
+		assert.Equal(t, "INFO", logEntry["level"])
+		assert.Equal(t, "HTTP Request", logEntry["msg"])
+		assert.Equal(t, "GET", logEntry["method"])
+		assert.Equal(t, "/test", logEntry["path"])
+		assert.Equal(t, "HTTP/1.1", logEntry["protocol"])
+		assert.Equal(t, "127.0.0.1:1234", logEntry["remote_ip"])
+		assert.Equal(t, "Test-Agent", logEntry["user_agent"])
+		assert.Equal(t, float64(http.StatusOK), logEntry["status"])
+		assert.Equal(t, float64(2), logEntry["bytes"]) // "OK" is 2 bytes
+		assert.NotNil(t, logEntry["duration"])
+	})
+
+	t.Run("logs 500 Internal Server Error as Error", func(t *testing.T) {
+		var buf bytes.Buffer
+		h := slog.NewJSONHandler(&buf, nil)
+		log := slog.New(h)
+
+		middleware := NewHTTPLogger(log)
+
+		handler := middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+			w.Write([]byte("error occurred"))
+		}))
+
+		req := httptest.NewRequest(http.MethodPost, "/error-path", nil)
+		rr := httptest.NewRecorder()
+
+		handler.ServeHTTP(rr, req)
+
+		assert.Equal(t, http.StatusInternalServerError, rr.Code)
+
+		var logEntry map[string]interface{}
+		err := json.Unmarshal(buf.Bytes(), &logEntry)
+		assert.NoError(t, err)
+
+		assert.Equal(t, "ERROR", logEntry["level"])
+		assert.Equal(t, "HTTP Request", logEntry["msg"])
+		assert.Equal(t, "POST", logEntry["method"])
+		assert.Equal(t, "/error-path", logEntry["path"])
+		assert.Equal(t, float64(http.StatusInternalServerError), logEntry["status"])
+		assert.Equal(t, float64(14), logEntry["bytes"]) // "error occurred" is 14 bytes
+	})
+
+	t.Run("uses default logger when nil is provided", func(t *testing.T) {
+		var buf bytes.Buffer
+
+		// Capture standard output for the default logger
+		h := slog.NewTextHandler(&buf, nil)
+		slog.SetDefault(slog.New(h))
+
+		middleware := NewHTTPLogger(nil)
+		handler := middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusCreated)
+		}))
+
+		req := httptest.NewRequest(http.MethodPut, "/default", nil)
+		rr := httptest.NewRecorder()
+
+		handler.ServeHTTP(rr, req)
+
+		assert.Equal(t, http.StatusCreated, rr.Code)
+		assert.Contains(t, buf.String(), "HTTP Request")
+		assert.Contains(t, buf.String(), "method=PUT")
+		assert.Contains(t, buf.String(), "path=/default")
+		assert.Contains(t, buf.String(), "status=201")
+	})
+
+	t.Run("defaults to 200 OK if WriteHeader is not called", func(t *testing.T) {
+		var buf bytes.Buffer
+		h := slog.NewJSONHandler(&buf, nil)
+		log := slog.New(h)
+
+		middleware := NewHTTPLogger(log)
+
+		handler := middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Write([]byte("no status code set"))
+		}))
+
+		req := httptest.NewRequest(http.MethodGet, "/no-status", nil)
+		rr := httptest.NewRecorder()
+
+		handler.ServeHTTP(rr, req)
+
+		var logEntry map[string]interface{}
+		err := json.Unmarshal(buf.Bytes(), &logEntry)
+		assert.NoError(t, err)
+
+		assert.Equal(t, "INFO", logEntry["level"])
+		assert.Equal(t, float64(http.StatusOK), logEntry["status"])
+		assert.Equal(t, float64(18), logEntry["bytes"])
+	})
+
+	t.Run("defaults to 200 OK if neither WriteHeader nor Write is called", func(t *testing.T) {
+		var buf bytes.Buffer
+		h := slog.NewJSONHandler(&buf, nil)
+		log := slog.New(h)
+
+		middleware := NewHTTPLogger(log)
+
+		handler := middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// Do nothing
+		}))
+
+		req := httptest.NewRequest(http.MethodGet, "/empty", nil)
+		rr := httptest.NewRecorder()
+
+		handler.ServeHTTP(rr, req)
+
+		var logEntry map[string]interface{}
+		err := json.Unmarshal(buf.Bytes(), &logEntry)
+		assert.NoError(t, err)
+
+		assert.Equal(t, "INFO", logEntry["level"])
+		assert.Equal(t, float64(http.StatusOK), logEntry["status"])
+		assert.Equal(t, float64(0), logEntry["bytes"])
+	})
+}

--- a/logger/http_test.go
+++ b/logger/http_test.go
@@ -131,6 +131,58 @@ func TestNewHTTPLogger(t *testing.T) {
 		assert.Equal(t, float64(18), logEntry["bytes"])
 	})
 
+	t.Run("uses X-Forwarded-For if available", func(t *testing.T) {
+		var buf bytes.Buffer
+		h := slog.NewJSONHandler(&buf, nil)
+		log := slog.New(h)
+
+		middleware := NewHTTPLogger(log)
+
+		handler := middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+
+		req := httptest.NewRequest(http.MethodGet, "/proxy", nil)
+		req.RemoteAddr = "10.0.0.1:1234"
+		req.Header.Set("X-Forwarded-For", "203.0.113.195, 198.51.100.1")
+
+		rr := httptest.NewRecorder()
+
+		handler.ServeHTTP(rr, req)
+
+		var logEntry map[string]interface{}
+		err := json.Unmarshal(buf.Bytes(), &logEntry)
+		assert.NoError(t, err)
+
+		assert.Equal(t, "203.0.113.195", logEntry["remote_ip"])
+	})
+
+	t.Run("uses X-Real-IP if available", func(t *testing.T) {
+		var buf bytes.Buffer
+		h := slog.NewJSONHandler(&buf, nil)
+		log := slog.New(h)
+
+		middleware := NewHTTPLogger(log)
+
+		handler := middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+
+		req := httptest.NewRequest(http.MethodGet, "/proxy", nil)
+		req.RemoteAddr = "10.0.0.1:1234"
+		req.Header.Set("X-Real-IP", "203.0.113.195")
+
+		rr := httptest.NewRecorder()
+
+		handler.ServeHTTP(rr, req)
+
+		var logEntry map[string]interface{}
+		err := json.Unmarshal(buf.Bytes(), &logEntry)
+		assert.NoError(t, err)
+
+		assert.Equal(t, "203.0.113.195", logEntry["remote_ip"])
+	})
+
 	t.Run("defaults to 200 OK if neither WriteHeader nor Write is called", func(t *testing.T) {
 		var buf bytes.Buffer
 		h := slog.NewJSONHandler(&buf, nil)


### PR DESCRIPTION
This PR implements an HTTP logging middleware based on `slog`. It addresses the need to log request details in an Apache-style format (including Method, Path, Remote IP, Status Code, Bytes Written, and Duration).

Key changes:
- `logger/http.go`: Implemented `NewHTTPLogger` factory function and internal `httpLogger` struct to wrap incoming HTTP requests. A custom `responseWriter` is used to capture the status code and response size.
- The logger automatically assigns `slog.LevelInfo` for status codes < 500 and `slog.LevelError` for status codes >= 500.
- Implemented `defer` in `ServeHTTP` to securely log even if a downstream handler panics.
- `logger/http_test.go`: Added extensive unit tests covering 200 responses, 500 responses, nil-logger defaults, and scenarios where handlers do not set a status code or body explicitly.

---
*PR created automatically by Jules for task [15211175374386625651](https://jules.google.com/task/15211175374386625651) started by @pushkar-anand*