### PR TITLE
⚡ [performance] pre-allocate map capacity in parseError

### DIFF
--- a/validator/validator.go
+++ b/validator/validator.go
@@ -112,7 +112,7 @@ func (v *Validator) parseError(err error) (*Result, error) {
 	case errors.As(err, &invalidErr):
 		return nil, fmt.Errorf("validation failed: %w", invalidErr)
 	case errors.As(err, &validationErrs):
-		failures := make(map[string]Reason)
+		failures := make(map[string]Reason, len(validationErrs))
 
 		for _, validationErr := range validationErrs {
 			field := validationErr.Field()


### PR DESCRIPTION
This PR implements a performance optimization in the validator package.

💡 **What:** The `failures` map in the `parseError` function is now pre-allocated with the capacity of `len(validationErrs)`.
🎯 **Why:** By providing a capacity hint, we avoid the overhead of multiple map reallocations and rehashes as validation errors are processed.
📊 **Measured Improvement:** Establishing a baseline was impractical due to the current environment's network and toolchain restrictions (Go 1.25 required, Go 1.24.3 available, and no network access to download dependencies). However, pre-allocating map capacity is a well-established Go performance best practice for reducing memory allocations and CPU cycles in loops.

---
*PR created automatically by Jules for task [4184455184694757367](https://jules.google.com/task/4184455184694757367) started by @pushkar-anand*