### PR TITLE
feat(logger): add support for SSE streaming via http.ResponseController

### DIFF
--- a/logger/http.go
+++ b/logger/http.go
@@ -29,6 +29,10 @@ func (rw *responseWriter) Write(b []byte) (int, error) {
 	return size, err
 }
 
+func (rw *responseWriter) Unwrap() http.ResponseWriter {
+	return rw.ResponseWriter
+}
+
 type httpLogger struct {
 	log  *slog.Logger
 	next http.Handler

--- a/logger/http_test.go
+++ b/logger/http_test.go
@@ -207,4 +207,40 @@ func TestNewHTTPLogger(t *testing.T) {
 		assert.Equal(t, float64(http.StatusOK), logEntry["status"])
 		assert.Equal(t, float64(0), logEntry["bytes"])
 	})
+
+	t.Run("supports ResponseController and SSE streaming", func(t *testing.T) {
+		var buf bytes.Buffer
+		h := slog.NewJSONHandler(&buf, nil)
+		log := slog.New(h)
+
+		middleware := NewHTTPLogger(log)
+
+		handler := middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "text/event-stream")
+			w.WriteHeader(http.StatusOK)
+
+			rc := http.NewResponseController(w)
+			w.Write([]byte("data: test\n\n"))
+
+			err := rc.Flush()
+			assert.NoError(t, err)
+		}))
+
+		req := httptest.NewRequest(http.MethodGet, "/stream", nil)
+		rr := httptest.NewRecorder()
+
+		handler.ServeHTTP(rr, req)
+
+		assert.Equal(t, http.StatusOK, rr.Code)
+		assert.Equal(t, "data: test\n\n", rr.Body.String())
+
+		var logEntry map[string]interface{}
+		err := json.Unmarshal(buf.Bytes(), &logEntry)
+		assert.NoError(t, err)
+
+		assert.Equal(t, "INFO", logEntry["level"])
+		assert.Equal(t, float64(http.StatusOK), logEntry["status"])
+		// The 12 bytes written
+		assert.Equal(t, float64(12), logEntry["bytes"])
+	})
 }


### PR DESCRIPTION
Adds `Unwrap()` to the internal `responseWriter` wrapper to support `http.ResponseController`.
This enables access to `http.Flusher`, which is required for Server-Sent Events (SSE) streaming.
Includes tests to verify functionality.

---
*PR created automatically by Jules for task [5033685094867741345](https://jules.google.com/task/5033685094867741345) started by @pushkar-anand*