### PR TITLE
🔒 [security fix] Remove sensitive data exposure in config logging

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1,11 +1,9 @@
 package config
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io/fs"
-	"log"
 	"os"
 	"strings"
 
@@ -75,8 +73,3 @@ func fileNotExistsErr(err error) bool {
 	return errors.Is(err, os.ErrNotExist) || errors.Is(err, fs.ErrNotExist)
 }
 
-func easyPrint(data interface{}) {
-	manifestJson, _ := json.MarshalIndent(data, "", "  ")
-
-	log.Println(string(manifestJson))
-}


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed is the potential exposure of sensitive configuration data through an unexported debugging function `easyPrint` in `config/config.go`.
⚠️ **Risk:** If used, this function would log arbitrary structs (like configuration objects) directly to the standard log, which could contain secrets, API keys, or other sensitive information, leading to data exposure.
🛡️ **Solution:** The `easyPrint` function and its associated unused imports (`encoding/json` and `log`) were removed from `config/config.go`. A thorough search confirmed that there were no internal call sites for this function, making its removal safe and effective.

---
*PR created automatically by Jules for task [16477502175619401174](https://jules.google.com/task/16477502175619401174) started by @pushkar-anand*