### PR TITLE
chore: remove unused easyPrint function from config

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1,11 +1,9 @@
 package config
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io/fs"
-	"log"
 	"os"
 	"strings"
 
@@ -73,10 +71,4 @@ func unmarshalConfig[T any](k *koanf.Koanf) (*T, error) {
 
 func fileNotExistsErr(err error) bool {
 	return errors.Is(err, os.ErrNotExist) || errors.Is(err, fs.ErrNotExist)
-}
-
-func easyPrint(data interface{}) {
-	manifestJson, _ := json.MarshalIndent(data, "", "  ")
-
-	log.Println(string(manifestJson))
 }


### PR DESCRIPTION
🎯 **What:** The code health issue addressed was the presence of an unused, unexported function `easyPrint` in `config/config.go`. It and its specific imports (`encoding/json`, `log`) have been removed.
💡 **Why:** Unused functions add dead weight to the codebase. Removing them reduces maintenance burden and clutter, and prevents compiler errors regarding unused imports.
✅ **Verification:** I removed the code and ran the `go test ./config/...` test suite to ensure that the configuration parsing logic remained completely intact and correctly formatted the codebase with `go fmt ./config`.
✨ **Result:** A cleaner `config` package without unused functions and imports, marginally improving code health and readability without altering any behavior.

---
*PR created automatically by Jules for task [10795492833794323642](https://jules.google.com/task/10795492833794323642) started by @pushkar-anand*